### PR TITLE
Add `aria-hidden` to the background divs

### DIFF
--- a/packages/rci/src/components/CodeInput.tsx
+++ b/packages/rci/src/components/CodeInput.tsx
@@ -71,7 +71,7 @@ export const CodeInput = ({
   return (
     <RCI.Context length={length} selection={selection}>
       <RCI.Root style={rootStyle} className={className}>
-        <RCI.Absolute style={{ zIndex: -1 }}>
+        <RCI.Absolute aria-hidden={true} style={{ zIndex: -1 }}>
           <RCI.SegmentRenderer children={renderSegment} />
         </RCI.Absolute>
         <RCI.InputScrollWrapper


### PR DESCRIPTION
Adding `aria-hidden="true"` to the presenational background divs should prevent them from being announced in a screen reader.