### PR TITLE
:recycle: remove firefox interval hack

### DIFF
--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -97,11 +97,12 @@ const useCodeInputEffect = ({
       previousRef.current = getSelectionState(input)
     }
 
-    input?.addEventListener('input', handler)
-    document.addEventListener('selectionchange', handler)
+    const handlerRef = handler // closure ref to added handler
+    input?.addEventListener('input', handlerRef)
+    document.addEventListener('selectionchange', handlerRef)
     return () => {
-      input?.removeEventListener('input', handler)
-      document.removeEventListener('selectionchange', handler)
+      input?.removeEventListener('input', handlerRef)
+      document.removeEventListener('selectionchange', handlerRef)
     }
   }, [inputRef, handler, previousRef])
 }

--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -81,16 +81,6 @@ const useCodeInputHandler = ({
   )
 }
 
-const selectionChange = (handler: (event: Event) => void): (() => void) => {
-  const type = 'selectionchange'
-  if (navigator.userAgent.includes(' Firefox/')) {
-    const interval = setInterval(handler, 16, { type })
-    return () => clearInterval(interval)
-  }
-  document.addEventListener(type, handler)
-  return () => document.removeEventListener(type, handler)
-}
-
 const useCodeInputEffect = ({
   inputRef,
   previousRef,
@@ -107,11 +97,11 @@ const useCodeInputEffect = ({
       previousRef.current = getSelectionState(input)
     }
 
-    const cleanupSelectionChange = selectionChange(handler)
     input?.addEventListener('input', handler)
+    document.addEventListener('selectionchange', handler)
     return () => {
-      cleanupSelectionChange()
       input?.removeEventListener('input', handler)
+      document.removeEventListener('selectionchange', handler)
     }
   }, [inputRef, handler, previousRef])
 }


### PR DESCRIPTION
Fixes https://github.com/leonardodino/rci/issues/10 (kind of)

This removes the setInterval for firefox, since it does not appear to be needed since firefox 55.  I would suggest that if users need to support versions older than that, they can use something like https://github.com/2is10/selectionchange-polyfill.  But calling a function every 16ms seems like overkill and a good way to drain batteries.  I could be wrong about this, but it worked correctly in my version of firefox (95) in local testing.

I also updated the codesandbox slightly to fix an annoying chrome behavior, in which nothing appeared to be focused after resetting the input following an error.  Maybe there's a better way to do that, but I couldn't find one.