### PR TITLE
:bug: fixes sandbox error case in chrome

### DIFF
--- a/packages/rci-sandbox/src/Example.tsx
+++ b/packages/rci-sandbox/src/Example.tsx
@@ -63,17 +63,7 @@ export const Example = ({ id, expected, autoFocus }: ExampleProps) => {
             setTimeout(() => {
               setState('input')
               input.value = ''
-              /* 
-                The focus selection mechanism is launched from 'selectionchange' or 'input' event.
-                If you want to set the input value programmatically, you need to dispatch an 'input' event 
-                to restore the right selection.
-                (BTW The RCI.Input component is not controllable with a value.)
-              */
-              const event = new Event('input', {
-                bubbles: true,
-                cancelable: true,
-              });
-              input.dispatchEvent(event);
+              input.dispatchEvent(new Event('input'))
               input.focus()
             }, 500)
           })

--- a/packages/rci-sandbox/src/Example.tsx
+++ b/packages/rci-sandbox/src/Example.tsx
@@ -63,6 +63,17 @@ export const Example = ({ id, expected, autoFocus }: ExampleProps) => {
             setTimeout(() => {
               setState('input')
               input.value = ''
+              /* 
+                The focus selection mechanism is launched from 'selectionchange' or 'input' event.
+                If you want to set the input value programmatically, you need to dispatch an 'input' event 
+                to restore the right selection.
+                (BTW The RCI.Input component is not controllable with a value.)
+              */
+              const event = new Event('input', {
+                bubbles: true,
+                cancelable: true,
+              });
+              input.dispatchEvent(event);
               input.focus()
             }, 500)
           })


### PR DESCRIPTION
In the example the input value is cleared via `input.value = ''`.
Yet the handler function that manage the selection logic is called on 'input' and 'selectionchange' so without an event dispatch it feels like the input is blurred on chrome.
I have also added some comments on the example.

fixes #10 