### PR TITLE
chore: use es2019 as target

### DIFF
--- a/packages/rci/tsconfig.json
+++ b/packages/rci/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["dom", "es2020"],
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2019",
     "rootDir": ".",
     "outDir": "./dist",
     "allowJs": true,

--- a/packages/use-code-input/tsconfig.json
+++ b/packages/use-code-input/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["dom", "es2020"],
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2019",
     "rootDir": ".",
     "outDir": "./dist",
     "allowJs": true,

--- a/packages/use-is-focused/tsconfig.json
+++ b/packages/use-is-focused/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["dom", "es2020"],
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2019",
     "rootDir": ".",
     "outDir": "./dist",
     "allowJs": true,


### PR DESCRIPTION
I would like to use your great library on a project using Webpack 4.
However you are using optional chaining and since Webpack 4 uses Acorn 6, optional chaining is not supported.
It would be great if you could target ES2019 for the next release.
See also: https://github.com/webpack/webpack/issues/10227