### PR TITLE
Widen accepted ref types for React 19 ref types

### DIFF
--- a/packages/rci/src/components/CodeInput.tsx
+++ b/packages/rci/src/components/CodeInput.tsx
@@ -4,7 +4,7 @@ import type { RenderSegmentFn } from '../types/RenderSegmentFn'
 import * as RCI from './RCI'
 
 export type CodeInputProps = RCI.InputProps & {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   renderSegment: RenderSegmentFn
 
   length?: number

--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -48,7 +48,7 @@ const useCodeInputHandler = ({
   previousRef,
   setSelection,
 }: {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   previousRef: React.MutableRefObject<SelectionState | undefined>
   setSelection: React.Dispatch<React.SetStateAction<SelectionState>>
 }) => {
@@ -86,7 +86,7 @@ const useCodeInputEffect = ({
   previousRef,
   handler,
 }: {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   previousRef: React.MutableRefObject<SelectionState | undefined>
   handler: (event: Event) => void
 }): void => {
@@ -107,7 +107,7 @@ const useCodeInputEffect = ({
   }, [inputRef, handler, previousRef])
 }
 
-export const useCodeInput = (inputRef: React.RefObject<HTMLInputElement>) => {
+export const useCodeInput = (inputRef: React.RefObject<HTMLInputElement | null>) => {
   const [selection, setSelection] = useState<SelectionState>(ZERO)
   const previousRef = useRef<SelectionState>()
   const handler = useCodeInputHandler({ inputRef, previousRef, setSelection })

--- a/packages/use-is-focused/src/index.ts
+++ b/packages/use-is-focused/src/index.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 
-export const useIsFocused = (inputRef: React.RefObject<HTMLInputElement>) => {
+export const useIsFocused = (inputRef: React.RefObject<HTMLInputElement | null>) => {
   const [isFocused, setIsFocused] = useState<boolean | undefined>(undefined)
   const isFocusedRef = useRef<boolean | undefined>(isFocused)
 


### PR DESCRIPTION
React 19 alters how refs are calculated, so allowing a null ref value is needed to be explicitly allowed now.

Otherwise:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/9c53050a-640a-4250-8dda-c6f235d961ff" />
