### PR TITLE
:sparkles: add support for react 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Run build
         run: pnpm run build
 
+      - name: List installed versions
+        run: pnpm --recursive list react react-dom @types/react @types/react-dom
+
       - name: Typecheck (react@18)
         run: pnpm run typecheck
 
@@ -28,6 +31,9 @@ jobs:
 
       - name: Update to latest react
         run: pnpm --recursive update --latest react react-dom @types/react @types/react-dom
+
+      - name: List installed versions
+        run: pnpm --recursive list react react-dom @types/react @types/react-dom
 
       - name: Typecheck (react@latest)
         run: pnpm run typecheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,17 @@ jobs:
       - name: Run build
         run: pnpm run build
 
+      - name: Typecheck (react@18)
+        run: pnpm run typecheck
+
       - name: Lint
         run: pnpm run format -l
 
       - name: Check Git Status
         run: git status --porcelain
+
+      - name: Update to latest react
+        run: pnpm --recursive update --latest react react-dom @types/react @types/react-dom
+
+      - name: Typecheck (react@latest)
+        run: pnpm run typecheck

--- a/packages/rci/src/components/CodeInput.tsx
+++ b/packages/rci/src/components/CodeInput.tsx
@@ -4,7 +4,7 @@ import type { RenderSegmentFn } from '../types/RenderSegmentFn'
 import * as RCI from './RCI'
 
 export type CodeInputProps = RCI.InputProps & {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   renderSegment: RenderSegmentFn
 
   length?: number

--- a/packages/rci/src/components/RCI.tsx
+++ b/packages/rci/src/components/RCI.tsx
@@ -47,7 +47,7 @@ export type InputProps = Omit<
   React.ComponentPropsWithRef<'input'>,
   'maxLength' | 'children' | 'value'
 >
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const Input = React.forwardRef<HTMLInputElement | null, InputProps>(
   (props, ref) => {
     const length = useLengthContext()
     return (

--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -111,7 +111,7 @@ export const useCodeInput = (
   inputRef: React.RefObject<HTMLInputElement | null>,
 ) => {
   const [selection, setSelection] = useState<SelectionState>(ZERO)
-  const previousRef = useRef<SelectionState>()
+  const previousRef = useRef<SelectionState | undefined>(undefined)
   const handler = useCodeInputHandler({ inputRef, previousRef, setSelection })
 
   useCodeInputEffect({ inputRef, previousRef, handler })

--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -107,7 +107,9 @@ const useCodeInputEffect = ({
   }, [inputRef, handler, previousRef])
 }
 
-export const useCodeInput = (inputRef: React.RefObject<HTMLInputElement | null>) => {
+export const useCodeInput = (
+  inputRef: React.RefObject<HTMLInputElement | null>,
+) => {
   const [selection, setSelection] = useState<SelectionState>(ZERO)
   const previousRef = useRef<SelectionState>()
   const handler = useCodeInputHandler({ inputRef, previousRef, setSelection })

--- a/packages/use-code-input/src/index.ts
+++ b/packages/use-code-input/src/index.ts
@@ -48,7 +48,7 @@ const useCodeInputHandler = ({
   previousRef,
   setSelection,
 }: {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   previousRef: React.MutableRefObject<SelectionState | undefined>
   setSelection: React.Dispatch<React.SetStateAction<SelectionState>>
 }) => {
@@ -86,7 +86,7 @@ const useCodeInputEffect = ({
   previousRef,
   handler,
 }: {
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
   previousRef: React.MutableRefObject<SelectionState | undefined>
   handler: (event: Event) => void
 }): void => {
@@ -107,7 +107,7 @@ const useCodeInputEffect = ({
   }, [inputRef, handler, previousRef])
 }
 
-export const useCodeInput = (inputRef: React.RefObject<HTMLInputElement>) => {
+export const useCodeInput = (inputRef: React.RefObject<HTMLInputElement | null>) => {
   const [selection, setSelection] = useState<SelectionState>(ZERO)
   const previousRef = useRef<SelectionState>()
   const handler = useCodeInputHandler({ inputRef, previousRef, setSelection })

--- a/packages/use-is-focused/src/index.ts
+++ b/packages/use-is-focused/src/index.ts
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 
-export const useIsFocused = (inputRef: React.RefObject<HTMLInputElement | null>) => {
+export const useIsFocused = (
+  inputRef: React.RefObject<HTMLInputElement | null>,
+) => {
   const [isFocused, setIsFocused] = useState<boolean | undefined>(undefined)
   const isFocusedRef = useRef<boolean | undefined>(isFocused)
 

--- a/packages/use-is-focused/src/index.ts
+++ b/packages/use-is-focused/src/index.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 
-export const useIsFocused = (inputRef: React.RefObject<HTMLInputElement>) => {
+export const useIsFocused = (inputRef: React.RefObject<HTMLInputElement | null>) => {
   const [isFocused, setIsFocused] = useState<boolean | undefined>(undefined)
   const isFocusedRef = useRef<boolean | undefined>(isFocused)
 


### PR DESCRIPTION
kudos @jasikpark for starting the work in https://github.com/leonardodino/rci/pull/32

- added some more lines to keep both types for react 18 and 19 working
- had to update the CI (https://github.com/leonardodino/rci/pull/33) as it had stopped working
